### PR TITLE
Use WebLicht production instance

### DIFF
--- a/WebLicht-Const-Parsing-DE.json
+++ b/WebLicht-Const-Parsing-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Constituency Parsing (German). The pipeline makes use of WebLicht's TCF converter, the tokenizer and sentence boundary detector of the IMS/Stuttgart , and the constituent parser from the Berkeley NLP project. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-Const-Parsing-EN.json
+++ b/WebLicht-Const-Parsing-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Constituency Parsing (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, and the statistical BLLIP/Charniak parser. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-Dep-Parsing-DE.json
+++ b/WebLicht-Dep-Parsing-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (German). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, the POS Tagger from the OpenNLP projet, and the MaltParser, a system for data-driven dependency parsing. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-Dep-Parsing-EN.json
+++ b/WebLicht-Dep-Parsing-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, the Jitar POS Tagger, and TurboParser, a multilingual dependency parser based on linear programming relaxations. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-Dep-Parsing-HR (RELDI).json
+++ b/WebLicht-Dep-Parsing-HR (RELDI).json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (Croatian). The easy-chain makes use of the RELDI software (see https://github.com/clarinsi), which tokenizes and lemmatizes the text, performs part-of-speech tagging, and subsequently, does dependency parsing. For RELDI specific inquiries, please contact nljubesi@gmail.com.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "hr",

--- a/WebLicht-Dep-Parsing-NL-ALPINO.json
+++ b/WebLicht-Dep-Parsing-NL-ALPINO.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (Dutch). The pipeline makes use of WebLicht's TCF converter, the tokenizer and sentence splitter from Alpino, and the Alpino dependency parser for Dutch. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "nl",

--- a/WebLicht-Dep-Parsing-SL (RELDI).json
+++ b/WebLicht-Dep-Parsing-SL (RELDI).json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (Slovenian). The easy-chain makes use of the RELDI software (see https://github.com/clarinsi), which tokenizes and lemmatizes the text, performs part-of-speech tagging, and subsequently, does dependency parsing. For RELDI specific inquiries, please contact nljubesi@gmail.com.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "sl",

--- a/WebLicht-Dep-Parsing-SR (RELDI).json
+++ b/WebLicht-Dep-Parsing-SR (RELDI).json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Dependency Parsing (Serbian). The easy-chain makes use of the RELDI software (see https://github.com/clarinsi), which tokenizes and lemmatizes the text, performs part-of-speech tagging, and subsequently, does dependency parsing. For RELDI specific inquiries, please contact nljubesi@gmail.com.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "sr",

--- a/WebLicht-Lemmas-DE.json
+++ b/WebLicht-Lemmas-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Lemmatization (German). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, and the IMS TreeTagger. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-Lemmas-EN.json
+++ b/WebLicht-Lemmas-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Lemmatization (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, the Jitar POS Tagger, and the lemmatizer service from MorphAdorner. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-Morphology-DE.json
+++ b/WebLicht-Morphology-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Morphological Analysis (German). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, and the IMS tool on German morphology. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-Morphology-EN.json
+++ b/WebLicht-Morphology-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Morphological Analysis (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, and the morphology analysis service from MorphAdorner. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-NamedEntities-DE.json
+++ b/WebLicht-NamedEntities-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for German Named Entity Recognition (German). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, the IMS TreeTagger, and a German Named Entity Recognizer that has been trained based on a maximum entropy approach using the OpenNLP maxent library. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-NamedEntities-EN.json
+++ b/WebLicht-NamedEntities-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Named Entity Recognition (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, and the Illinois Named Entity Recognizer. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-NamedEntities-SL.json
+++ b/WebLicht-NamedEntities-SL.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for Named Entity Recognition (Slovenian). The easy-chain makes use of the ReLDI tag, NER JSI software, which performs NER without a parse.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "sl",

--- a/WebLicht-POSTags-Lemmas-DE.json
+++ b/WebLicht-POSTags-Lemmas-DE.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for POS Tagging and Lemmatization (German). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, and the IMS TreeTagger. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "de",

--- a/WebLicht-POSTags-Lemmas-EN.json
+++ b/WebLicht-POSTags-Lemmas-EN.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for POS Tagging and Lemmatization (English). The pipeline makes use of WebLicht's TCF converter, the Stanford tokenizer, the Jitar POS Tagger, and the lemmatizer service from MorphAdorner. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "en",

--- a/WebLicht-POSTags-Lemmas-FR.json
+++ b/WebLicht-POSTags-Lemmas-FR.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for POS Tagging and Lemmatization (French). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, and the IMS TreeTagger. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "fr",

--- a/WebLicht-POSTags-Lemmas-IT.json
+++ b/WebLicht-POSTags-Lemmas-IT.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for POS Tagging and Lemmatization (Italian). The pipeline makes use of WebLicht's TCF converter, the IMS tokenizer, and the POS Tagger from the OpenNLP project. The model for Italian is trained on a relatively small training corpus (MIDT) and should therefore be considered experimental. WebLicht's Tundra can be used to visualize the result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "it",

--- a/WebLicht-Tokenization-TUR.json
+++ b/WebLicht-Tokenization-TUR.json
@@ -12,7 +12,7 @@
         "email": "wlsupport@sfs.uni-tuebingen.de"
     },
     "version": "v1.0",
-    "authentication": "no",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
     "licence": "public",
     "description": "WebLicht Easy Chain for tokenization of Turkish texts. The pipeline makes use of WebLicht's TCF converter, and the tokenizer from the OpenNLP project. The 'newlineBounds' parameter treats newlines as a hard break (a sentence boundary). WebLicht's built-in viewer for annotations can be used to visualize the processing result.",
     "languages": [
@@ -29,7 +29,7 @@
     "output": [
         "application/tcf+xml"
     ],
-    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht-switchboard/",
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
         "input": "self.linkToResource",
         "lang": "tr",


### PR DESCRIPTION
This PR changes the url for Weblicht services to use the production instance, and also changes the authentication info (Shibboleth login required).