### PR TITLE
Add weblicht custom/advanced mode

### DIFF
--- a/tools/WebLicht.json
+++ b/tools/WebLicht.json
@@ -1,0 +1,34 @@
+{
+    "task": "Text Analytics",
+    "deployment": "production",
+    "name": "WebLicht Advanced Mode",
+    "logo": "weblicht.jpg",
+    "homepage": "https://weblicht.sfs.uni-tuebingen.de/weblichtwiki/index.php/Main_Page",
+    "location": "Tuebingen, Germany",
+    "creators": "CLARIN-D Centre at the University of Tuebingen, Germany",
+    "contact": {
+        "person": "CLARIN WebLicht Support",
+        "email": "wlsupport@sfs.uni-tuebingen.de"
+    },
+    "version": "v1.0",
+    "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
+    "licence": null,
+    "description": "This tool links to the WebLicht environment without preselecting an execution chain. WebLicht is an execution environment for automatic annotation of text corpora. Linguistic tools such as tokenizers, part of speech taggers, and parsers are encapsulated as web services, which can be combined by the user into custom processing chains. The resulting annotations can then be visualized in an appropriate way, such as in a table or tree format.",
+    "languages": ["generic"],
+    "langEncoding": "639-1",
+    "mimetypes": [
+        "text/plain",
+        "text/rtf",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ],
+    "output": [
+        "application/tcf+xml"
+    ],
+    "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
+    "parameters": {
+        "input": "",
+        "lang": ""
+    }
+}


### PR DESCRIPTION
This PR adds weblicht without a predefined chain, allowing the user to either select an easy chain or build their own. 

**Warning** This PR is based on the new tree structure from #24, merge #24 first!

fixes #23 