### PR TITLE
normalize input and language parameters (set to null)

### DIFF
--- a/tools/Alpino.json
+++ b/tools/Alpino.json
@@ -30,7 +30,7 @@
     "url": "https://webservices-lst.science.ru.nl/alpino/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "untokinput_url"

--- a/tools/Apache Stanbol Enhancer.json
+++ b/tools/Apache Stanbol Enhancer.json
@@ -27,7 +27,7 @@
     ],
     "url": "https://enrich-lrs.acdh.oeaw.ac.at/StanbolWrapper",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "outFormat": "application%2Fjson"
     },
     "mapping": {

--- a/tools/CSTLemma (hosted by D4Science).json
+++ b/tools/CSTLemma (hosted by D4Science).json
@@ -27,7 +27,7 @@
     ],
     "url": "https://next.d4science.org/nlp-hub-cstlemma/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "27061e4d-3567-482d-9f12-3a1af5e42ab9-843339462"
     }
 }

--- a/tools/Colibri Core (folia+xml).json
+++ b/tools/Colibri Core (folia+xml).json
@@ -35,8 +35,8 @@
     "url": "https://webservices-lst.science.ru.nl/colibricore/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource",
-        "lang": "self.linkToResourceLanguage",
+        "input": null,
+        "lang": null,
         "sentenceperline_input": "false",
         "sentenceperline_output": "false"
     },

--- a/tools/Colibri Core (plain text).json
+++ b/tools/Colibri Core (plain text).json
@@ -35,8 +35,8 @@
     "url": "https://webservices-lst.science.ru.nl/colibricore/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource",
-        "lang": "self.linkToResourceLanguage",
+        "input": null,
+        "lang": null,
         "sentenceperline_input": "false",
         "sentenceperline_output": "false"
     },

--- a/tools/Concraft -> Bartek -> NicolasSummarizer.json
+++ b/tools/Concraft -> Bartek -> NicolasSummarizer.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "6"
     }
 }

--- a/tools/Concraft -> Bartek.json
+++ b/tools/Concraft -> Bartek.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "5"
     }
 }

--- a/tools/Concraft -> DependencyParser.json
+++ b/tools/Concraft -> DependencyParser.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "4"
     }
 }

--- a/tools/Concraft -> Nerf.json
+++ b/tools/Concraft -> Nerf.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "2"
     }
 }

--- a/tools/Concraft -> Sentipejd.json
+++ b/tools/Concraft -> Sentipejd.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "3"
     }
 }

--- a/tools/Concraft->Spejd.json
+++ b/tools/Concraft->Spejd.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "1"
     }
 }

--- a/tools/Concraft.json
+++ b/tools/Concraft.json
@@ -30,7 +30,7 @@
     ],
     "url": "http://multiservice.nlp.ipipan.waw.pl/en/clrs",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "analysis": "0"
     }
 }

--- a/tools/D4Science NER (GATE's Annie).json
+++ b/tools/D4Science NER (GATE's Annie).json
@@ -27,7 +27,7 @@
     ],
     "url": "https://next.d4science.org/nlp-hub/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "a92dc66c-bf09-48cb-9a96-8e765f11e7b1-843339462"
     }
 }

--- a/tools/Distanbol.json
+++ b/tools/Distanbol.json
@@ -27,7 +27,7 @@
     ],
     "url": "https://distanbol.acdh.oeaw.ac.at/convert",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "confidence": "confidence"
     },
     "mapping": {

--- a/tools/FoLiA-stats.json
+++ b/tools/FoLiA-stats.json
@@ -31,7 +31,7 @@
     "url": "https://webservices-lst.science.ru.nl/foliastats/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "foliainput_url"

--- a/tools/Fowlt (plain text).json
+++ b/tools/Fowlt (plain text).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/fowlt/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "textinput_url"

--- a/tools/Fowlt (xml+folia).json
+++ b/tools/Fowlt (xml+folia).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/fowlt/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "foliainput_url"

--- a/tools/Frog (folia+xml).json
+++ b/tools/Frog (folia+xml).json
@@ -29,7 +29,7 @@
     "url": "https://webservices-lst.science.ru.nl/frog/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "foliainput_url"

--- a/tools/Frog (plain text).json
+++ b/tools/Frog (plain text).json
@@ -29,7 +29,7 @@
     "url": "https://webservices-lst.science.ru.nl/frog/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "maininput_url"

--- a/tools/Inkluz.json
+++ b/tools/Inkluz.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "inkluz"
     }

--- a/tools/Iobber.json
+++ b/tools/Iobber.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "chunker"
     }

--- a/tools/Liner2 (hosted by D4Science).json
+++ b/tools/Liner2 (hosted by D4Science).json
@@ -27,7 +27,7 @@
     ],
     "url": "https://next.d4science.org/nlp-hub-liner2/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "27061e4d-3567-482d-9f12-3a1af5e42ab9-843339462"
     }
 }

--- a/tools/Liner2.json
+++ b/tools/Liner2.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "ner"
     }

--- a/tools/MaltParser.json
+++ b/tools/MaltParser.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "parser"
     }

--- a/tools/Morfeusz 2.json
+++ b/tools/Morfeusz 2.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "morpho"
     }

--- a/tools/MorphoDiTa.json
+++ b/tools/MorphoDiTa.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "morphoDiTa"
     }

--- a/tools/NER NLTK.json
+++ b/tools/NER NLTK.json
@@ -34,7 +34,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "nerNLTK"
     }

--- a/tools/NLP-HUB (multiple NER tools).json
+++ b/tools/NLP-HUB (multiple NER tools).json
@@ -31,7 +31,7 @@
     ],
     "url": "https://nlp.d4science.org/hub",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "a92dc66c-bf09-48cb-9a96-8e765f11e7b1-843339462"
     }
 }

--- a/tools/Oersetter (FRY-NLD).json
+++ b/tools/Oersetter (FRY-NLD).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/oersetter/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "input-fy_url"

--- a/tools/Oersetter (NLD-FRY).json
+++ b/tools/Oersetter (NLD-FRY).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/oersetter/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "input-nl_url"

--- a/tools/Opener_Tokenizer_plain2tcf.json
+++ b/tools/Opener_Tokenizer_plain2tcf.json
@@ -33,7 +33,7 @@
 	"url": "http://ilc4clarin.ilc.cnr.it/services/opener/tokenizer/lrs",
 	"parameters": {
 		"input": null,
-		"lang": "self.linkToResourceLanguage",
+		"lang": null,
 		"format": "tcf"
 	},
 	"mapping": {

--- a/tools/ReSpa.json
+++ b/tools/ReSpa.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "respa"
     }

--- a/tools/Serel.json
+++ b/tools/Serel.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "serel"
     }

--- a/tools/Spacy (hosted by D4Science) - DE.json
+++ b/tools/Spacy (hosted by D4Science) - DE.json
@@ -28,7 +28,7 @@
     ],
     "url": "https://next.d4science.org/nlp-hub-spacyGerman/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "27061e4d-3567-482d-9f12-3a1af5e42ab9-843339462"
     }
 }

--- a/tools/Spacy (hosted by D4Science) - EN.json
+++ b/tools/Spacy (hosted by D4Science) - EN.json
@@ -28,7 +28,7 @@
     ],
     "url": "https://next.d4science.org/nlp-hub-spacyEnglish/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "token": "27061e4d-3567-482d-9f12-3a1af5e42ab9-843339462"
     }
 }

--- a/tools/Spatial.json
+++ b/tools/Spatial.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "spatial"
     }

--- a/tools/Spejd.json
+++ b/tools/Spejd.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "spejd"
     }

--- a/tools/Summarize.json
+++ b/tools/Summarize.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "summarize"
     }

--- a/tools/T-scan.json
+++ b/tools/T-scan.json
@@ -30,7 +30,7 @@
     "url": "https://webservices-lst.science.ru.nl/tscan/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "textinput_url"

--- a/tools/TF-IDF.json
+++ b/tools/TF-IDF.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "tfidf"
     }

--- a/tools/Tagger NLTK.json
+++ b/tools/Tagger NLTK.json
@@ -34,7 +34,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "tagerNLTK"
     }

--- a/tools/TermoPL.json
+++ b/tools/TermoPL.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "termopl"
     }

--- a/tools/Topic.json
+++ b/tools/Topic.json
@@ -27,7 +27,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "topic",
         "batch": "true"

--- a/tools/UDPipe.json
+++ b/tools/UDPipe.json
@@ -78,8 +78,8 @@
     ],
     "url": "https://lindat.mff.cuni.cz/services/udpipe/",
     "parameters": {
-        "input": "self.linkToResource",
-        "lang": "self.linkToResourceLanguage"
+        "input": null,
+        "lang": null
     },
     "mapping": {
         "input": "data",

--- a/tools/Ucto.json
+++ b/tools/Ucto.json
@@ -37,8 +37,8 @@
     "url": "https://webservices-lst.science.ru.nl/ucto/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource",
-        "lang": "self.linkToResourceLanguage"
+        "input": null,
+        "lang": null
     },
     "mapping": {
         "input": "untokinput_url",

--- a/tools/Valkuil (folia+xml).json
+++ b/tools/Valkuil (folia+xml).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/valkuil/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "foliainput_url"

--- a/tools/Valkuil (plain text).json
+++ b/tools/Valkuil (plain text).json
@@ -28,7 +28,7 @@
     "url": "https://webservices-lst.science.ru.nl/valkuil/",
     "parameters": {
         "project": "new",
-        "input": "self.linkToResource"
+        "input": null
     },
     "mapping": {
         "input": "textinput_url"

--- a/tools/Voyant Tools.json
+++ b/tools/Voyant Tools.json
@@ -37,6 +37,6 @@
     ],
     "url": "https://voyant-tools.org/",
     "parameters": {
-        "input": "self.linkToResource"
+        "input": null
     }
 }

--- a/tools/WCRFT2.json
+++ b/tools/WCRFT2.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "tagger"
     }

--- a/tools/WebLicht-Const-Parsing-DE.json
+++ b/tools/WebLicht-Const-Parsing-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "const-parsing"
     }

--- a/tools/WebLicht-Const-Parsing-EN.json
+++ b/tools/WebLicht-Const-Parsing-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "const-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-DE.json
+++ b/tools/WebLicht-Dep-Parsing-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-EN.json
+++ b/tools/WebLicht-Dep-Parsing-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-HR (RELDI).json
+++ b/tools/WebLicht-Dep-Parsing-HR (RELDI).json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "hr",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-NL-ALPINO.json
+++ b/tools/WebLicht-Dep-Parsing-NL-ALPINO.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "nl",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-SL (RELDI).json
+++ b/tools/WebLicht-Dep-Parsing-SL (RELDI).json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "sl",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Dep-Parsing-SR (RELDI).json
+++ b/tools/WebLicht-Dep-Parsing-SR (RELDI).json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "sr",
         "analysis": "dep-parsing"
     }

--- a/tools/WebLicht-Lemmas-DE.json
+++ b/tools/WebLicht-Lemmas-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "lemma"
     }

--- a/tools/WebLicht-Lemmas-EN.json
+++ b/tools/WebLicht-Lemmas-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "lemma"
     }

--- a/tools/WebLicht-Morphology-DE.json
+++ b/tools/WebLicht-Morphology-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "morphology"
     }

--- a/tools/WebLicht-Morphology-EN.json
+++ b/tools/WebLicht-Morphology-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "morphology"
     }

--- a/tools/WebLicht-NamedEntities-DE.json
+++ b/tools/WebLicht-NamedEntities-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "ne"
     }

--- a/tools/WebLicht-NamedEntities-EN.json
+++ b/tools/WebLicht-NamedEntities-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "ne"
     }

--- a/tools/WebLicht-NamedEntities-SL.json
+++ b/tools/WebLicht-NamedEntities-SL.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "sl",
         "analysis": "ne"
     }

--- a/tools/WebLicht-POSTags-Lemmas-DE.json
+++ b/tools/WebLicht-POSTags-Lemmas-DE.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "de",
         "analysis": "pos"
     }

--- a/tools/WebLicht-POSTags-Lemmas-EN.json
+++ b/tools/WebLicht-POSTags-Lemmas-EN.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "en",
         "analysis": "pos"
     }

--- a/tools/WebLicht-POSTags-Lemmas-FR.json
+++ b/tools/WebLicht-POSTags-Lemmas-FR.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "fr",
         "analysis": "pos"
     }

--- a/tools/WebLicht-POSTags-Lemmas-IT.json
+++ b/tools/WebLicht-POSTags-Lemmas-IT.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "it",
         "analysis": "pos"
     }

--- a/tools/WebLicht-Tokenization-TUR.json
+++ b/tools/WebLicht-Tokenization-TUR.json
@@ -31,7 +31,7 @@
     ],
     "url": "https://weblicht.sfs.uni-tuebingen.de/weblicht/",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "tr",
         "analysis": "token"
     }

--- a/tools/WebSty.json
+++ b/tools/WebSty.json
@@ -32,8 +32,8 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
-        "lang": "self.linkToResourceLanguage",
+        "input": null,
+        "lang": null,
         "analysis": "websty",
         "batch": "true"
     }

--- a/tools/WoSeDon.json
+++ b/tools/WoSeDon.json
@@ -35,7 +35,7 @@
     ],
     "url": "https://ws.clarin-pl.eu/weblicht.html",
     "parameters": {
-        "input": "self.linkToResource",
+        "input": null,
         "lang": "pl",
         "analysis": "wsd"
     }


### PR DESCRIPTION
Replace all "self.linkToResource*" strings with null, in the tool definitions. The code only checks the parameter name (input, lang, type) and provides the correct values without checking the json value.