### PR TITLE
iso 639-3 for French is fra not fre

### DIFF
--- a/tools/LINDAT Translation.json
+++ b/tools/LINDAT Translation.json
@@ -21,7 +21,7 @@
         "rus",
         "ces",
         "eng",
-        "fre"
+        "fra"
     ],
     "mimetypes": [
         "text/plain"


### PR DESCRIPTION
Fixes wrong iso code.

Are the CORS headers set the same way on beta-switchboard.clarin.eu as on the production one?
Is there a way to add newlines into description; `\n` does not seem to work.
Is there a way to turn text into link, e.g. in the license field.