### PR TITLE
voyant accepts any tei file

### DIFF
--- a/tools/Voyant Tools.json
+++ b/tools/Voyant Tools.json
@@ -30,6 +30,7 @@
         "application/pdf",
         "application/msword",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/tei+xml",
         "application/tei+xml;format-variant=tei-dta"
     ],
     "output": [


### PR DESCRIPTION
We have to specify both `application/tei+xml` and `application/tei+xml;format-variant=dta`, as they are considered separate mediatypes.