### PR TITLE
Remove authentication string, set to "no"

### DIFF
--- a/tools/DARIAH-DE-Geo-Browser-CSV.json
+++ b/tools/DARIAH-DE-Geo-Browser-CSV.json
@@ -11,7 +11,7 @@
         "email": "support@de.dariah.eu"
     },
     "version": "v3.6-BETA",
-    "authentication": "DARIAH AAI (restricted resources), none (public resources)",
+    "authentication": "no",
     "description": "The DARIAH-DE Geo-Browser allows a comparative visualization of several requests and facilitates the representation of data and their visualization in a correlation of geographic spatial relations at corresponding points of time and sequences. Thus, researchers can analyze space-time relations of data and collections of source material and simultaneously establish correlations between them.",
     "licence": "LGPL-3.0-or-later",
     "output": [
@@ -22,7 +22,6 @@
         "application/vnd.dariahde.geobrowser.csv"
     ],
     "languages": [
-        "eng",
         "generic"
     ],
     "langEncoding": "639-1",

--- a/tools/DARIAH-DE-Geo-Browser-KML.json
+++ b/tools/DARIAH-DE-Geo-Browser-KML.json
@@ -11,7 +11,7 @@
         "email": "support@de.dariah.eu"
     },
     "version": "v3.6-BETA",
-    "authentication": "DARIAH AAI (restricted resources), none (public resources)",
+    "authentication": "no",
     "description": "The DARIAH-DE Geo-Browser allows a comparative visualization of several requests and facilitates the representation of data and their visualization in a correlation of geographic spatial relations at corresponding points of time and sequences. Thus, researchers can analyze space-time relations of data and collections of source material and simultaneously establish correlations between them.",
     "licence": "LGPL-3.0-or-later",
     "output": [
@@ -23,7 +23,6 @@
         "application/vnd.dariahde.geobrowser.kml+xml"
     ],
     "languages": [
-        "eng",
         "generic"
     ],
     "langEncoding": "639-1",


### PR DESCRIPTION
1. Remove authentication string, set to "no"

We have only AAI if needed for datasets from Datasheet Editor, no AAI will be far more be used

2. Remove language english, generic only seems to be better

Does this make any sense in language handling for Switchboard? We do not need english source input at all.