### PR TITLE
Ramove content of language array to avoid language specific tool choice.

### DIFF
--- a/tools/DARIAH-DE-Geo-Browser-CSV.json
+++ b/tools/DARIAH-DE-Geo-Browser-CSV.json
@@ -22,9 +22,7 @@
         "text/comma-separated-value",
         "application/vnd.dariahde.geobrowser.csv"
     ],
-    "languages": [
-        "generic"
-    ],
+    "languages": [],
     "langEncoding": "639-1",
     "url": "https://geobrowser.de.dariah.eu/beta/",
     "parameters": {

--- a/tools/DARIAH-DE-Geo-Browser-KML.json
+++ b/tools/DARIAH-DE-Geo-Browser-KML.json
@@ -22,9 +22,7 @@
         "application/vnd.google-earth.kmz",
         "application/vnd.dariahde.geobrowser.kml+xml"
     ],
-    "languages": [
-        "generic"
-    ],
+    "languages": [],
     "langEncoding": "639-1",
     "url": "https://geobrowser.de.dariah.eu/beta/",
     "parameters": {


### PR DESCRIPTION
Is the language setting correct for generic setting now? The tools won't validate with this empty language array (though other tools have configured it the same way...)