### PR TITLE
changed mimetype to audio/vorbis

### DIFF
--- a/tools/Automatic Transcription of Dutch Speech Recordings (Ogg file).json
+++ b/tools/Automatic Transcription of Dutch Speech Recordings (Ogg file).json
@@ -24,7 +24,7 @@
         "topic": "OH"
     },
     "mimetypes": [
-        "audio/ogg"
+        "audio/vorbis"
     ],
     "languages": [
         "nld"


### PR DESCRIPTION
The output of the Tika-based profiler goes deeper than the ogg container. Updated this entry to enable the match.