### PR TITLE
Fix parameter typo (Polish tag)

### DIFF
--- a/tools/WCRFT2.json
+++ b/tools/WCRFT2.json
@@ -36,6 +36,6 @@
     "parameters": {
         "input": null,
         "lang": "pl",
-        "analysis": "tagger"
+        "analysis": "tager"
     }
 }


### PR DESCRIPTION
This fix comes from an email communication with Tomasz Walkowiak:

> You have in URL analysis=tagger
> When we expect 'tager' (one g less, this is in Polish).