### PR TITLE
Added mapping lang -> input specs of Text Tonsorium

### DIFF
--- a/tools/texton-lemmas.json
+++ b/tools/texton-lemmas.json
@@ -85,13 +85,14 @@
         "UIlanguage": "en",
         "Ifacet": "txt",
         "Iambig": "una",
-        "Iapp": "nrm",
+        "Iapp": "nrm"
         "Ofacet": "lem",
         "Operiod": "c21",
         "Opres": "nml"
     },
     "mapping": {
         "input": "URLS",
+        "lang": "Ilang",
         "lang": "Olang"
     }
 

--- a/tools/texton-lemmas.json
+++ b/tools/texton-lemmas.json
@@ -85,7 +85,7 @@
         "UIlanguage": "en",
         "Ifacet": "txt",
         "Iambig": "una",
-        "Iapp": "nrm"
+        "Iapp": "nrm",
         "Ofacet": "lem",
         "Operiod": "c21",
         "Opres": "nml"


### PR DESCRIPTION
In mail, I wrote that I also would add that the output should be 'unambiguous'. I did not do this, since the Text Tonsorium not always is able to deliver completely disambiguated output given some input language and input format.

Currently, 'lang' maps both to 'Ilang' and to 'Olang'. I hope the Switchboard can handle this. 