### PR TITLE
allow adding a reference to a schema file in tool configurations

### DIFF
--- a/schemas/spec-v1.schema.json
+++ b/schemas/spec-v1.schema.json
@@ -24,6 +24,10 @@
     "url"
   ],
   "properties": {
+    "$schema": {
+      "type": "string",
+      "pattern": "^../schemas/"
+    },
     "task": {
       "$id": "#/properties/task",
       "type": "string",

--- a/schemas/spec-v2.schema.json
+++ b/schemas/spec-v2.schema.json
@@ -20,6 +20,10 @@
     ],
     "additionalProperties": false,
     "properties": {
+        "$schema": {
+            "type": "string",
+            "pattern": "^../schemas/"
+        },
         "formatVersion": {
             "type": "string",
             "enum": ["2"]

--- a/tools/Octra.json
+++ b/tools/Octra.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schemas/spec-v2.schema.json",
   "formatVersion": "2",
   "id": 155,
   "task": "Speech transcription",

--- a/tools/TranscriptionPortal.json
+++ b/tools/TranscriptionPortal.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../schemas/spec-v2.schema.json",
   "formatVersion": "2",
   "id": 154,
   "task": "Editing",


### PR DESCRIPTION
The optional property `$schema` enables validation support for IDEs and helps devs to create correct configuration files on the fly. ref #186