### PR TITLE
TranscriptionPortal: support for separated modes: Annotation Mode, Summarization Mode

### DIFF
--- a/tools/TranscriptionPortal-Annotation.json
+++ b/tools/TranscriptionPortal-Annotation.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "../schemas/spec-v2.schema.json",
+  "formatVersion": "2",
+  "id": 154,
+  "task": "Speech Recognition",
+  "deployment": "production",
+  "integrationType": "External",
+  "name": "TranscriptionPortal (Annotation Mode)",
+  "description": "A portal that implements a transcription chain for batch processing of speech files. In annotation mode you are able to transcribe audio files automatically using ASR, correct the transcript using Octra, automatically align the transcript into words and edit the phonetic details in EmuWebApp.",
+  "logo": "transcription-portal.png",
+  "homepage": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/annotation",
+  "creators": "Julian Pömp, Christoph Draxler",
+  "contact": {
+    "person": "Christoph Draxler",
+    "email": "draxler@phonetik.uni-muenchen.de"
+  },
+  "keywords": ["transcription", "annotation", "asr", "audio-transcribing", "audio-transcription"],
+  "location": "Munich, Germany",
+  "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
+  "inputs": [
+    {
+      "id": "audio",
+      "name": "Speech",
+      "maxSize": 314572800,
+      "mediatypes": [
+        "audio/vnd.wav",
+        "audio/vnd.wave",
+        "audio/wav",
+        "audio/wave",
+        "audio/x-pn-wav",
+        "audio/x-wav"
+      ],
+      "languages": ["deu", "eng", "ita", "nld"]
+    },
+    {
+      "id": "transcript",
+      "maxSize": 20971520,
+      "mediatypes": [
+        "text/plain",
+        "text/vtt",
+        "text/praat-textgrid",
+        "application/json"
+      ],
+      "optional": true,
+      "languages": ["deu", "eng", "ita", "nld"]
+    }
+  ],
+  "webApplication": {
+    "url": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/annotation",
+    "queryParameters": [
+      {
+        "name": "audio",
+        "bind": "audio/dataurl"
+      },
+      {
+        "name": "audio_language",
+        "bind": "audio/language"
+      },
+      {
+        "name": "audio_type",
+        "bind": "audio/type"
+      },
+      {
+        "name": "transcript",
+        "bind": "transcript/dataurl"
+      },
+      {
+        "name": "transcript_type",
+        "bind": "transcript/type"
+      }
+    ]
+  }
+}

--- a/tools/TranscriptionPortal-Summarization.json
+++ b/tools/TranscriptionPortal-Summarization.json
@@ -1,20 +1,20 @@
 {
   "$schema": "../schemas/spec-v2.schema.json",
   "formatVersion": "2",
-  "id": 154,
+  "id": 156,
   "task": "Speech Recognition",
   "deployment": "production",
   "integrationType": "External",
-  "name": "TranscriptionPortal",
-  "description": "A portal that implements a transcription chain for batch processing of speech files using automatic speech recognition, the OCTRA editor, the Munich Automatic Segmentation MAUS and the EMU-webApp viewer.",
+  "name": "TranscriptionPortal (Summarization Mode)",
+  "description": "A portal that implements a transcription chain for batch processing of speech files. In summarization mode you automatically transcribe audio files using ASR, check the transcript in Octra, summarize the transcript using AI and translate it to a selected language automatically.",
   "logo": "transcription-portal.png",
-  "homepage": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/",
+  "homepage": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/summarization",
   "creators": "Julian Pömp, Christoph Draxler",
   "contact": {
     "person": "Christoph Draxler",
     "email": "draxler@phonetik.uni-muenchen.de"
   },
-  "keywords": ["transcription", "annotation", "asr", "audio-transcribing", "audio-transcription"],
+  "keywords": ["transcription", "annotation", "asr", "audio-transcribing", "audio-transcription", "summarization", "translation"],
   "location": "Munich, Germany",
   "authentication": "Requires a CLARIN Service Provider Federation account, provided by many universities and institutions.",
   "inputs": [
@@ -46,7 +46,7 @@
     }
   ],
   "webApplication": {
-    "url": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/",
+    "url": "https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/summarization",
     "queryParameters": [
       {
         "name": "audio",


### PR DESCRIPTION
The new version of the TranscriptionPortal allows users to access one specific mode by URL:

- Annotation Mode: https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/annotation
- Summarization Mode: https://clarin.phonetik.uni-muenchen.de/apps/TranscriptionPortal/summarization

With the new configuration files users can select between the modes on the switchboard.